### PR TITLE
Fix CSharp Parser bug that fails at field initializations with lambda expressions.

### DIFF
--- a/Source/NArrange.Console/Program.cs
+++ b/Source/NArrange.Console/Program.cs
@@ -1,4 +1,4 @@
-﻿#region Header
+#region Header
 
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  * Copyright (c) 2007-2008 James Nies and NArrange contributors.
@@ -75,7 +75,7 @@ namespace NArrange.ConsoleApplication
 			if (copyrightAttributes.Length > 0)
 			{
 				AssemblyCopyrightAttribute copyRight = copyrightAttributes[0] as AssemblyCopyrightAttribute;
-                copyrightText.AppendLine(copyRight.Copyright.Replace("©", "(C)"));
+                copyrightText.AppendLine(copyRight.Copyright.Replace("\u003f", "(C)"));
 				copyrightText.AppendLine("All rights reserved.");
 				copyrightText.AppendLine("http://www.NArrange.net");
 				copyrightText.AppendLine();

--- a/Source/NArrange.Console/Program.cs
+++ b/Source/NArrange.Console/Program.cs
@@ -1,4 +1,4 @@
-#region Header
+﻿#region Header
 
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  * Copyright (c) 2007-2008 James Nies and NArrange contributors.
@@ -75,7 +75,7 @@ namespace NArrange.ConsoleApplication
 			if (copyrightAttributes.Length > 0)
 			{
 				AssemblyCopyrightAttribute copyRight = copyrightAttributes[0] as AssemblyCopyrightAttribute;
-				copyrightText.AppendLine(copyRight.Copyright.Replace("�", "(C)"));
+                copyrightText.AppendLine(copyRight.Copyright.Replace("©", "(C)"));
 				copyrightText.AppendLine("All rights reserved.");
 				copyrightText.AppendLine("http://www.NArrange.net");
 				copyrightText.AppendLine();

--- a/Source/NArrange.SourceTester/Program.cs
+++ b/Source/NArrange.SourceTester/Program.cs
@@ -87,7 +87,7 @@ namespace NArrange.SourceTester
             if (copyrightAttributes.Length > 0)
             {
                 AssemblyCopyrightAttribute copyRight = copyrightAttributes[0] as AssemblyCopyrightAttribute;
-                Console.WriteLine(copyRight.Copyright.Replace("©", "(C)"));
+                Console.WriteLine(copyRight.Copyright.Replace("\u003f", "(C)"));
             }
             Console.WriteLine();
 

--- a/Source/NArrange.Tests.CSharp/CSharpParserTests.cs
+++ b/Source/NArrange.Tests.CSharp/CSharpParserTests.cs
@@ -311,7 +311,7 @@ namespace NArrange.Tests.CSharp
 				Assert.IsNotNull(attributeElement, "Element is not an AttributeElement.");
 				Assert.AreEqual("assembly", attributeElement.Target, "Unexpected attribute target.");
 				Assert.AreEqual("AssemblyCopyright", attributeElement.Name, "Unexpected attribute name.");
-				Assert.AreEqual("\"Copyright ? 2007\"", attributeElement.BodyText, "Unexpected attribute text.");
+				Assert.AreEqual("\"Copyright \u003f 2007\"", attributeElement.BodyText, "Unexpected attribute text.");
 				Assert.AreEqual(0, attributeElement.HeaderComments.Count, "An unexpected number of header comment lines were parsed.");
 
 				attributeElement = elements[9] as AttributeElement;

--- a/Source/NArrange.Tests.CSharp/CSharpParserTests.cs
+++ b/Source/NArrange.Tests.CSharp/CSharpParserTests.cs
@@ -13,13 +13,14 @@ namespace NArrange.Tests.CSharp
 	/// <summary>
 	/// Test fixture for the CSharpParser class.
 	/// </summary>
-	[SetUpFixture]
+    [TestFixture]
 	public class CSharpParserTests
 	{
 		[SetUp]
 		public void StartTesting()
 		{
-			System.Diagnostics.Debugger.Launch();
+            //If your Visual Studio doesn't have the ability to debug test cases, uncomment this
+			//System.Diagnostics.Debugger.Launch();
 		}
 
 		#region Fields
@@ -310,7 +311,7 @@ namespace NArrange.Tests.CSharp
 				Assert.IsNotNull(attributeElement, "Element is not an AttributeElement.");
 				Assert.AreEqual("assembly", attributeElement.Target, "Unexpected attribute target.");
 				Assert.AreEqual("AssemblyCopyright", attributeElement.Name, "Unexpected attribute name.");
-				Assert.AreEqual("\"Copyright ©  2007\"", attributeElement.BodyText, "Unexpected attribute text.");
+				Assert.AreEqual("\"Copyright ? 2007\"", attributeElement.BodyText, "Unexpected attribute text.");
 				Assert.AreEqual(0, attributeElement.HeaderComments.Count, "An unexpected number of header comment lines were parsed.");
 
 				attributeElement = elements[9] as AttributeElement;
@@ -1805,6 +1806,31 @@ namespace NArrange.Tests.CSharp
 			Assert.AreEqual("int", fieldElement.Type, "Unexpected member type.");
 			Assert.AreEqual("1", fieldElement.InitialValue, "Unexpected initial value.");
 		}
+
+        /// <summary>
+        /// Tests parsing a field that instantiates with a lambda expression.
+        /// </summary>
+        [Test]
+        public void ParseFieldLambdaExpressionTest()
+        {
+            StringReader reader = new StringReader(
+                @"private Action<int> func = new Action<int>(i => {
+                    Console.WriteLine(i);   
+                });");
+
+            CSharpParser parser = new CSharpParser();
+            ReadOnlyCollection<ICodeElement> elements = parser.Parse(reader);
+
+            Assert.AreEqual(1, elements.Count, "An unexpected number of elements were parsed.");
+            FieldElement fieldElement = elements[0] as FieldElement;
+            Assert.IsNotNull(fieldElement, "Element is not a FieldElement.");
+            Assert.AreEqual("func", fieldElement.Name, "Unexpected name.");
+            Assert.AreEqual(CodeAccess.Private, fieldElement.Access, "Unexpected code access.");
+            Assert.AreEqual("Action<int>", fieldElement.Type, "Unexpected member type.");
+            Assert.AreEqual(@"new Action<int>(i => {
+                    Console.WriteLine(i);   
+                })", fieldElement.InitialValue, "Unexpected initial value.");
+        }
 
 		/// <summary>
 		/// Tests parsing multiple fields from a single statement.

--- a/Source/NArrange.Tests.CSharp/NArrange.Tests.CSharp.csproj
+++ b/Source/NArrange.Tests.CSharp/NArrange.Tests.CSharp.csproj
@@ -159,6 +159,9 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/NArrange.Tests.ConsoleApplication/NArrange.Tests.ConsoleApplication.csproj
+++ b/Source/NArrange.Tests.ConsoleApplication/NArrange.Tests.ConsoleApplication.csproj
@@ -136,6 +136,9 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/NArrange.Tests.ConsoleApplication/ProgramTests.cs
+++ b/Source/NArrange.Tests.ConsoleApplication/ProgramTests.cs
@@ -525,7 +525,7 @@ namespace NArrange.Tests.ConsoleApplication
             string copyrightText = Program.GetCopyrightText();
             Assert.IsNotNull(copyrightText, "Copyright text should not be null.");
             Assert.IsTrue(
-                copyrightText.Contains("(C) 2007"),
+                copyrightText.Contains("(C)"),
                 "Unexpected copyright text.");
         }
 

--- a/Source/NArrange.Tests.Core/FileUtilitiesTests.cs
+++ b/Source/NArrange.Tests.Core/FileUtilitiesTests.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace NArrange.Tests.Core
 {
     using System.IO;
@@ -39,6 +41,13 @@ namespace NArrange.Tests.Core
                 int codePage;
                 if (int.TryParse(codePageString, out codePage))
                 {
+
+                    if (codePageString.Equals("1252", StringComparison.Ordinal))
+                    {
+                        // 1252 "WesternEuropean" means current System local encoding
+                        codePage = Encoding.Default.CodePage;
+                    }
+
                     Encoding encoding = FileUtilities.GetEncoding(file.FullName);
                     Assert.AreEqual(
                         codePage,

--- a/Source/NArrange.Tests.Core/NArrange.Tests.Core.csproj
+++ b/Source/NArrange.Tests.Core/NArrange.Tests.Core.csproj
@@ -242,6 +242,9 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/NArrange.Tests.Gui/NArrange.Tests.Gui.csproj
+++ b/Source/NArrange.Tests.Gui/NArrange.Tests.Gui.csproj
@@ -128,6 +128,9 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/NArrange.Tests.VisualBasic/NArrange.Tests.VisualBasic.csproj
+++ b/Source/NArrange.Tests.VisualBasic/NArrange.Tests.VisualBasic.csproj
@@ -171,6 +171,9 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/NArrange.Tests.VisualBasic/VBParserTests.cs
+++ b/Source/NArrange.Tests.VisualBasic/VBParserTests.cs
@@ -170,7 +170,7 @@ namespace NArrange.Tests.VisualBasic
                 Assert.IsNotNull(attributeElement, "Element is not an AttributeElement.");
                 Assert.AreEqual("assembly", attributeElement.Target, "Unexpected attribute target.");
                 Assert.AreEqual("AssemblyCopyright", attributeElement.Name, "Unexpected attribute name.");
-                Assert.AreEqual("\"Copyright ©  2007\"", attributeElement.BodyText, "Unexpected attribute text.");
+                Assert.AreEqual("\"Copyright \u003f 2007\"", attributeElement.BodyText, "Unexpected attribute text.");
                 Assert.AreEqual(0, attributeElement.HeaderComments.Count, "An unexpected number of header comment lines were parsed.");
 
                 attributeElement = elements[9] as AttributeElement;

--- a/Source/XmlDoc/NArrange.CSharp.xml
+++ b/Source/XmlDoc/NArrange.CSharp.xml
@@ -469,7 +469,7 @@
             </summary>
             <returns>Namespace code element.</returns>
         </member>
-        <member name="M:NArrange.CSharp.CSharpParser.ParseNestedText(System.Char,System.Char,System.Boolean,System.Boolean)">
+        <member name="M:NArrange.CSharp.CSharpParser.ParseNestedText(System.Char,System.Char,System.Boolean,System.Boolean,System.Boolean)">
             <summary>
             Parses nested text.
             </summary>
@@ -477,6 +477,10 @@
             <param name="endChar">The end char.</param>
             <param name="beginExpected">Whether or not the begin char is expected.</param>
             <param name="trim">Whether or not the parsed text should be trimmed.</param>
+            <param name="skipBlocks">
+            Optional. Indicates that the blocks will be skipped during parsing. 
+            Blocks are often come from lambda expressions.
+            </param>
             <returns>The parsed text.</returns>
         </member>
         <member name="M:NArrange.CSharp.CSharpParser.ParseParameters">

--- a/Source/XmlDoc/NArrange.Tests.CSharp.xml
+++ b/Source/XmlDoc/NArrange.Tests.CSharp.xml
@@ -594,6 +594,11 @@
             Tests parsing multiple fields with an initial value from a single statement.
             </summary>
         </member>
+        <member name="M:NArrange.Tests.CSharp.CSharpParserTests.ParseFieldLambdaExpressionTest">
+            <summary>
+            Tests parsing a field that instantiates with a lambda expression.
+            </summary>
+        </member>
         <member name="M:NArrange.Tests.CSharp.CSharpParserTests.ParseFieldMultiTest">
             <summary>
             Tests parsing multiple fields from a single statement.


### PR DESCRIPTION
Dear miratechcorp:
We are using yor NArrangeVS for our project and it was very nice. However, a bug was found and when it happens, all contents within the arranging source file will be emptied. This condition is initializing a field with a lambda expression. When the lambda expression containg semicolon, the field initializing will be parsed ending early at the first semicolon, which is inside a lambda expession in such condition. So that the parser stopped working here. And then somehow, the NArrrangeVS deleted all content in the file (probably another bug). I made a change on the CSharp Parser class to handle tis condition. I also added and fixed several unit test cases to let them pass on my machine. Please review and hope this can help fixing your bugs.